### PR TITLE
Quadrotor Simulator Module PATH Changed

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -1,7 +1,9 @@
 import numpy as np
 import sys
 
-sys.path.append('../')
+import os
+qs_path = os.getcwd()+'/..'
+sys.path.append(qs_path)
 
 from quadrotor_simulator_py.utils import Pose
 from quadrotor_simulator_py.utils import Quaternion


### PR DESCRIPTION
I changed the path to the **quadrotor_simulator_py** module in **tests.py** to run the script from any directory.